### PR TITLE
docs: Update social and skills badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@
 
 ## Socials:
 
-[![image](https://github.com/creative-tutorials/creative-tutorials/assets/68476321/75c82787-3268-4675-a1c0-25db460ef708)](https://linkedin.com/in/treasure-alekhojie) [![image](https://github.com/creative-tutorials/creative-tutorials/assets/68476321/5003311a-a817-4f49-bcda-07812b8b8fa7)](https://twitter.com/timi_networks)
+[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/timi_networks?style=for-the-badge&logo=x&labelColor=black&link=https%3A%2F%2Ftwitter.com%2Ftimi_networks)](https://twitter.com/timi_networks) [![LinkedIn follow](https://img.shields.io/badge/LinkedIn-Follow-black?style=for-the-badge&logo=linkedin&labelColor=black&link=https%3A%2F%2Fwww.linkedin.com%2Fin%2Ftreasure-alekhojie%2F)](https://www.linkedin.com/in/treasure-alekhojie/)
+
+
+
 
 
 
 
 # Passionate about:
-![TypeScript](https://img.shields.io/badge/Typescript-%23000000?style=for-the-badge&logo=typescript) ![React](https://img.shields.io/badge/React-%23000000?style=for-the-badge&logo=react) ![Next JS](https://img.shields.io/badge/Next.js-%23000000?style=for-the-badge&logo=next.js) ![Supabase](https://img.shields.io/badge/Supabase-%23000000?style=for-the-badge&logo=supabase)
+![TypeScript](https://img.shields.io/badge/Typescript-%23000000?style=for-the-badge&logo=typescript) ![React Query](https://img.shields.io/badge/react%20query-%23000000?style=for-the-badge&logo=react%20query) ![React](https://img.shields.io/badge/React-%23000000?style=for-the-badge&logo=react) ![Next JS](https://img.shields.io/badge/Next.js-%23000000?style=for-the-badge&logo=next.js) ![Supabase](https://img.shields.io/badge/Supabase-%23000000?style=for-the-badge&logo=supabase) ![MongoDB](https://img.shields.io/badge/MongoDB-%23000000?style=for-the-badge&logo=mongodb)
+
 # Stats:
 ![](https://github-readme-stats.vercel.app/api?username=creative-tutorials&theme=tokyonight&hide_border=false&include_all_commits=true&count_private=true)<br/>
 
 <!-- Proudly created with GPRM ( https://gprm.itsvg.in ) -->
+
+
+


### PR DESCRIPTION
### TL;DR

This PR updates the social links and skills badges in the README.

### What changed?

The direct images for social links have been replaced with shields.io badges, providing a cleaner look. The skills badges have also been updated, adding React Query and MongoDB badges.

### How to test?

Please check the README.md on the repository's main page to see the new social links and skills badges. 

### Why make this change?

To provide a cleaner, more modern look to the README, and to accurately reflect the current skills and means of connection.

---

